### PR TITLE
Fixed removeEdge() when from or to vertices are empty

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: graph
 Title: graph: A package to handle graph data structures
-Version: 1.85.2
+Version: 1.85.3
 Authors@R: c(
         person("R", "Gentleman", role = "aut"),
         person("Elizabeth", "Whalen", role="aut"),

--- a/R/methods-graphBAM.R
+++ b/R/methods-graphBAM.R
@@ -806,6 +806,9 @@ setReplaceMethod("edgemode", c("graphBAM", "character"),
    
     lenFrom <- length(from)
     lenTo <- length(to)
+    if (lenFrom < 1 || lenTo < 1)
+        return(graph)
+
     if(lenFrom != lenTo) {
         if(lenFrom ==1)
             from <- rep(from, lenTo)

--- a/inst/unitTests/graphBAM_test.R
+++ b/inst/unitTests/graphBAM_test.R
@@ -226,7 +226,7 @@ test_BAM_removeEdge <- function()
     g1 <- make_smallBAM()
     ## removing nothing does nothing
     c0 <- character(0)
-#    checkEquals(edges(g1), edges(removeEdge(c0, c0, g1)))
+    checkEquals(edges(g1), edges(removeEdge(c0, c0, g1)))
     ## there is no y => a edge, throw error
     checkException(removeEdge("y", "a", g1), silent=TRUE)
 


### PR DESCRIPTION
This PR fixes a core dump error triggered by the line:

```r
ord <- .Call(graph_bitarray_getEdgeAttrOrder,  graph@edgeSet@bit_vector ,
            as.integer(req_from), as.integer(req_to))
```
in the `.remEdge()` function from the `R/methods-graphBAM.R` file, which is called by `removeEdge(from, to graph)` when either `from` or `to` are empty character vectors. The suggested solution consists of returning the same input graph in the call to `.remEdge()` whenever `from` or `to` have length smaller than 1. This PR resolves issue #24 