### PR TITLE
Fix PROTECT/UNPROTECT imbalance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: graph
 Title: graph: A package to handle graph data structures
-Version: 1.89.0
+Version: 1.89.1
 Authors@R: c(
         person("R", "Gentleman", role = "aut"),
         person("Elizabeth", "Whalen", role="aut"),

--- a/src/graph.c
+++ b/src/graph.c
@@ -120,7 +120,7 @@ SEXP graph_intersection(SEXP xN, SEXP yN, SEXP xE, SEXP yE,
     if (length(bN) == 0) {
 	SET_SLOT(outGraph, Rf_install("nodes"), allocVector(STRSXP, 0));
 	SET_SLOT(outGraph, Rf_install("edgeL"), allocVector(VECSXP, 0));
-	UNPROTECT(1);
+	UNPROTECT(2);
 	return(outGraph);
     }
     PROTECT(newXE = checkEdgeList(xE, bN));


### PR DESCRIPTION
I think this was reported in https://stat.ethz.ch/pipermail/bioc-devel/2017-April/010771.html but looking at the git history, it was never fixed.

Results from Tomas Kalibera's run: https://github.com/kalibera/rprotect/blob/master/reports/graph/BioC_graph.so.bcheck

You can find a more recent rchk run here: https://github.com/Bisaloo/graph/actions/runs/19859086615/job/56904300740